### PR TITLE
Serdine-derive: Add other missing path qualifiers

### DIFF
--- a/serdine/src/deserialize_test.rs
+++ b/serdine/src/deserialize_test.rs
@@ -1,5 +1,3 @@
-use std::{io::Read, mem};
-
 use crate::{self as serdine, Deserialize};
 use serdine_derive::Deserialize;
 
@@ -18,7 +16,7 @@ pub struct MyNamedFieldsStruct {
     pub my_vec: Vec<u8>,
 }
 
-fn deserialize_vec<R: Read>(mut r: R) -> Vec<u8> {
+fn deserialize_vec<R: std::io::Read>(mut r: R) -> Vec<u8> {
     let mut buffer = Vec::new();
     r.read_to_end(&mut buffer).unwrap();
     buffer

--- a/serdine/src/deserialize_test.rs
+++ b/serdine/src/deserialize_test.rs
@@ -1,4 +1,5 @@
-use crate::{self as serdine, Deserialize};
+use crate as serdine;
+use crate::Deserialize as DeserializeDisambiguate;
 use serdine_derive::Deserialize;
 
 // ////////////////////////////////////////////////////////////////////////////////
@@ -67,7 +68,7 @@ fn test_deserialize_enum() {
 
     let mut reader = serialized_bytes;
 
-    assert_eq!(MyEnum::VarA, Deserialize::deserialize(&mut reader));
-    assert_eq!(MyEnum::VarC, Deserialize::deserialize(&mut reader));
-    assert_eq!(MyEnum::VarB, Deserialize::deserialize(&mut reader));
+    assert_eq!(MyEnum::VarA, serdine::Deserialize::deserialize(&mut reader));
+    assert_eq!(MyEnum::VarC, serdine::Deserialize::deserialize(&mut reader));
+    assert_eq!(MyEnum::VarB, serdine::Deserialize::deserialize(&mut reader));
 }

--- a/serdine/src/serialize_test.rs
+++ b/serdine/src/serialize_test.rs
@@ -1,4 +1,5 @@
-use crate::{self as serdine, Serialize};
+use crate as serdine;
+use crate::Serialize as DeserializeDisambiguate;
 use serdine_derive::Serialize;
 
 // ////////////////////////////////////////////////////////////////////////////////

--- a/serdine/src/serialize_test.rs
+++ b/serdine/src/serialize_test.rs
@@ -1,5 +1,3 @@
-use std::io::Write;
-
 use crate::{self as serdine, Serialize};
 use serdine_derive::Serialize;
 
@@ -18,7 +16,7 @@ pub struct MyNamedFieldsStruct {
     pub my_vec: Vec<u8>,
 }
 
-fn serialize_vec<W: Write>(vec: &Vec<u8>, mut w: W) {
+fn serialize_vec<W: std::io::Write>(vec: &Vec<u8>, mut w: W) {
     for instance in vec {
         instance.serialize(&mut w);
     }

--- a/serdine_derive/src/deserialize.rs
+++ b/serdine_derive/src/deserialize.rs
@@ -90,7 +90,7 @@ fn impl_trait_with_enum_variants(
 
     Ok(quote!(
         impl Deserialize for #type_name {
-            fn deserialize<R: Read>(mut r: R) -> Self {
+            fn deserialize<R: std::io::Read>(mut r: R) -> Self {
                 let mut buffer = [0; std::mem::size_of::<Self>()];
 
                 r.read_exact(&mut buffer).unwrap();

--- a/serdine_derive/src/deserialize.rs
+++ b/serdine_derive/src/deserialize.rs
@@ -89,7 +89,7 @@ fn impl_trait_with_enum_variants(
     );
 
     Ok(quote!(
-        impl Deserialize for #type_name {
+        impl serdine::Deserialize for #type_name {
             fn deserialize<R: std::io::Read>(mut r: R) -> Self {
                 let mut buffer = [0; std::mem::size_of::<Self>()];
 


### PR DESCRIPTION
Also made tests more robust, by removing imports.