### PR TITLE
Cargo manifest: Explicitly set `readme` attribute

### DIFF
--- a/serdine/Cargo.toml
+++ b/serdine/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Saverio Miroddi <saverio.pub2@gmail.com>"]
 edition = "2021"
 rust-version = "1.56.1"
 description = "A tiny serialization library for storing types in a raw (but safe), memcpy-like, format"
+readme = "../README.md"
 homepage = "https://github.com/64kramsystem/serdine"
 repository = "https://github.com/64kramsystem/serdine"
 license = "MIT"

--- a/serdine_derive/Cargo.toml
+++ b/serdine_derive/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Saverio Miroddi <saverio.pub2@gmail.com>"]
 edition = "2021"
 rust-version = "1.56.1"
 description = "Derive macros for serdine crate"
+readme = "../README.md"
 homepage = "https://github.com/64kramsystem/serdine"
 repository = "https://github.com/64kramsystem/serdine"
 license = "MIT"


### PR DESCRIPTION
This allows correct display of the logo on crates.io, otherwise, the site will decode the logo relative to directory where the crate manifest resides.